### PR TITLE
Improve lens correction for RT

### DIFF
--- a/include/go2_driver/modules/go2_camera.hpp
+++ b/include/go2_driver/modules/go2_camera.hpp
@@ -86,6 +86,9 @@ private:
   int roi_height_;
   int roi_width_;
   bool roi_do_rectify_;
+
+  // Precompute lens correction interpolation
+  cv::Mat mapX_, mapY_;
 };
 
 }  // namespace go2_driver

--- a/src/go2_driver/modules/go2_camera.cpp
+++ b/src/go2_driver/modules/go2_camera.cpp
@@ -85,6 +85,9 @@ CallbackReturnT Go2Camera::on_configure()
 
   RCLCPP_INFO(node_->get_logger(), "\033[1;34mCamera module configured.\033[0m");
 
+  // Precompute undistort map for lens correction 
+  cv::initUndistortRectifyMap(k_, d_, cv::Matx33f::eye(), k_, cv::SIZE(width_, height_), CV_32FC1, mapX_, mapY_);
+
   return CallbackReturnT::SUCCESS;
 }
 
@@ -200,11 +203,9 @@ void Go2Camera::front_video_data_callback(const unitree_go::msg::Go2FrontVideoDa
   cv::Mat bgr;
   cv::cvtColor(yuv420p, bgr, cv::COLOR_YUV420p2RGB);
 
-  cv::Mat K = cv::Mat(3, 3, CV_64F, k_.data());
-  cv::Mat D = cv::Mat(1, d_.size(), CV_64F, d_.data());
   cv::Mat dst;
-
-  cv::undistort(bgr, dst, K, D);
+  // Undistort image using remap to improve performance
+  cv::remap(bgr, dst, mapX_, mapY_, cv::INTER_LINEAR);
 
   auto image_msg = cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", dst).toImageMsg();
   image_msg->header.stamp = node_->get_clock()->now();


### PR DESCRIPTION
In OpenCV, undistort methods compute the full transformation every time they are called. By precomputing the lens correction maps with initUndistortRectifyMap, you can significantly improve performance in real-time applications by using remap to efficiently apply the correction to each frame.

Regards :)