### PR TITLE
Add publisher for base IMU on /imu_lowstate

### DIFF
--- a/include/go2_driver/go2_driver.hpp
+++ b/include/go2_driver/go2_driver.hpp
@@ -34,6 +34,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
+#include <sensor_msgs/msg/imu.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -67,7 +68,7 @@ private:
   void publish_lidar(const sensor_msgs::msg::PointCloud2::SharedPtr msg);
   void publish_pose_stamped(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
   void joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg);
-  void publish_joint_states(const unitree_go::msg::LowState::SharedPtr msg);
+  void low_state_handler(const unitree_go::msg::LowState::SharedPtr msg);
   void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
 
   void handleBodyHeight(
@@ -124,7 +125,7 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_pub_;
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
-  rclcpp::Publisher<unitree_go::msg::IMUState>::SharedPtr imu_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
   rclcpp::Publisher<unitree_api::msg::Request>::SharedPtr request_pub_;
 
   rclcpp::Service<go2_interfaces::srv::BodyHeight>::SharedPtr set_body_height_service_;

--- a/src/go2_driver/go2_driver.cpp
+++ b/src/go2_driver/go2_driver.cpp
@@ -44,7 +44,7 @@ Go2Driver::Go2Driver(
   pointcloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>("pointcloud", 10);
   joint_state_pub_ = create_publisher<sensor_msgs::msg::JointState>("joint_states", 10);
   odom_pub_ = create_publisher<nav_msgs::msg::Odometry>("odom", qos_profile);
-  imu_pub_ = create_publisher<unitree_go::msg::IMUState>("imu", 10);
+  imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("/imu_lowstate", 10);
   request_pub_ = create_publisher<unitree_api::msg::Request>("api/sport/request", 10);
 
   pointcloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
@@ -60,7 +60,7 @@ Go2Driver::Go2Driver(
 
   low_state_sub_ = create_subscription<unitree_go::msg::LowState>(
     "lowstate", 10,
-    std::bind(&Go2Driver::publish_joint_states, this, std::placeholders::_1));
+    std::bind(&Go2Driver::low_state_handler, this, std::placeholders::_1));
 
   cmd_vel_sub_ = create_subscription<geometry_msgs::msg::Twist>(
     "cmd_vel", 10, std::bind(&Go2Driver::cmd_vel_callback, this, std::placeholders::_1));
@@ -173,7 +173,7 @@ void Go2Driver::joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg)
   joy_state_ = *msg;
 }
 
-void Go2Driver::publish_joint_states(const unitree_go::msg::LowState::SharedPtr msg)
+void Go2Driver::low_state_handler(const unitree_go::msg::LowState::SharedPtr msg)
 {
   sensor_msgs::msg::JointState joint_state;
   joint_state.header.stamp = now();
@@ -188,6 +188,28 @@ void Go2Driver::publish_joint_states(const unitree_go::msg::LowState::SharedPtr 
     msg->motor_state[6].q, msg->motor_state[7].q, msg->motor_state[8].q};
 
   joint_state_pub_->publish(joint_state);
+
+  sensor_msgs::msg::Imu imu_msg;
+  imu_msg.header.stamp = now();
+  imu_msg.header.frame_id = "imu";
+
+  std::array<float, 4> q = msg->imu_state.quaternion;
+  imu_msg.orientation.x = q[1];
+  imu_msg.orientation.y = q[2];
+  imu_msg.orientation.z = q[3];
+  imu_msg.orientation.w = q[0];
+
+  std::array<float, 3> gyro = msg->imu_state.gyroscope;
+  imu_msg.angular_velocity.x = gyro[0];
+  imu_msg.angular_velocity.y = gyro[1];
+  imu_msg.angular_velocity.z = gyro[2];
+
+  std::array<float, 3> accel = msg->imu_state.accelerometer;
+  imu_msg.linear_acceleration.x = accel[0];
+  imu_msg.linear_acceleration.y = accel[1];
+  imu_msg.linear_acceleration.z = accel[2];
+  
+  imu_pub_->publish(imu_msg);
 }
 
 void Go2Driver::cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg)


### PR DESCRIPTION
### Description

As discussed in [Issue 41](https://github.com/Unitree-Go2-Robot/go2_robot/issues/41) of the `go2_robot` repository, there is currently no topic for the base IMU data in a standard ROS2 `sensor_msgs` format being published.

This PR is a simple adjustment to the callback that handles the `lowstate` messages of the Go2, extracing the IMU state and publishing it under `/imu_lowstate´.

### Checklist
- [ ] I have formatted the code to pass the CI.
- [ ] Extend the test.

### Screenshots / Images / Videos
Unfortunately, I am not at the office right now but I tested it and already used the topic in my code. A simple `ros2 topic list` and `ros2 topic echo` and comparing to the data reported by `/lowstate´ shows that it's functioning correctly.
